### PR TITLE
Missing await in .play()

### DIFF
--- a/lib/audio.dart
+++ b/lib/audio.dart
@@ -348,7 +348,7 @@ class Audio
         {
             players.forEach((uid, player)
             {
-                player.pause();
+                await player.pause();
             });
         }
 


### PR DESCRIPTION
This missing await can mess with the flow of the player and is the probable source of problems with play() listed in issue #14